### PR TITLE
sphinx執筆環境の改善(gulpによる自動ビルド・確認)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,17 @@ zunda-cafeのissue/wiki用リポジトリ
   * SphinxをビルドしたHTMLを公開用に配置するディレクトリ
   * 暫定で手でビルドしたHTMLを配置
 
-### 将来的な運用イメージ
+## Gulp(タスクランナーを用いた簡易確認)
+* `gulp` コマンドでwatch、Webサーバ起動
+* source配下のrstファイルに変更があると`make html` が実行される
+* 最初に起動された`localhost:4000`のページはLiveReloadされ、結果の確認が可能
+
+### gulpの使用準備
+* `npm -v` コマンドが通ることを確認
+* `npm install gulp -g` でgulpコマンドが使用できるようになる
+* zunda-cafe をcloneしたフォルダで`npm install` とすると、package.jsonに従い必要なライブラリがnode_modulesに入る。
+
+## 将来的な運用イメージ
 1. `develop`ブランチへドキュメント変更のPullRequestを送る
 2. 逐次masterへマージ
 3. マージされたらTravisCIでSphinxをビルド

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,26 @@
+/** reSTファイルの変更を感知、ビルドしてブラウザでLiveReload */
+
+var gulp = require('gulp'),
+  webserver = require('gulp-webserver'),
+  shell = require('gulp-shell');
+
+var SERVER_PORT = 4000;
+
+
+gulp.task('watch', function () {
+  gulp.watch(['./source/*.rst', './source/**/*.rst'],
+      shell.task(['make html'])
+  );
+});
+
+gulp.task('serve', function () {
+  gulp.src('./build/html')
+    .pipe(webserver({
+      livereload: true,
+      open: true,
+      port: SERVER_PORT
+    }));
+});
+
+gulp.task('default', ['watch', 'serve']);
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "zunda-cafe",
+  "version": "0.0.1",
+  "description": "zunda-cafe",
+  "main": "gulpfile.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "devDependencies": {
+    "gulp": "3.8.0",
+    "gulp-shell": "0.5.0",
+    "gulp-webserver": "0.8.0"
+  }
+}


### PR DESCRIPTION
レビューお願いします。 #12 

package.jsonにある3ライブラリのバージョンが少し古いですが、それぞれ最新の組み合わせで試すと、「gulp-shell」にてasync.jsのよくわからんエラーが出るので、マイナーバージョンを下げて安定を図っています。
これで今のところ動いてるのでまぁ良しとしてます。

**特にMac環境の方**
この組み合わせでエラーが起こらないか、見てもらえるとうれしいです（環境依存か否か）
